### PR TITLE
feat: add GitHub and generic inbound webhook endpoints

### DIFF
--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -18,4 +18,12 @@ describe("GitHubAdapter", () => {
     expect(parseMention("hey @ove-bot review PR #5", "ove-bot")).toBe("hey  review PR #5");
     expect(parseMention("no mention here", "ove-bot")).toBeNull();
   });
+
+  test("parseMention handles botName with regex metacharacters", async () => {
+    const { parseMention } = await import("./github");
+    // botName like "bot[1]" would break if used in a regex without escaping
+    expect(parseMention("@bot[1] fix this", "bot[1]")).toBe("fix this");
+    expect(parseMention("@bot.star do it", "bot.star")).toBe("do it");
+    expect(parseMention("@bot(x) hello", "bot(x)")).toBe("hello");
+  });
 });

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -2,8 +2,9 @@ import type { EventAdapter, IncomingEvent, EventSource, AdapterStatus } from "./
 import { logger } from "../logger";
 
 export function parseMention(body: string, botName: string): string | null {
-  if (!body.includes(`@${botName}`)) return null;
-  return body.replace(new RegExp(`@${botName}`, "g"), "").trim();
+  const mention = "@" + botName;
+  if (!body.includes(mention)) return null;
+  return body.replaceAll(mention, "").trim();
 }
 
 interface GitHubComment {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -25,7 +25,7 @@ export interface ChatAdapter {
 export type EventSource =
   | { type: "issue"; repo: string; number: number }
   | { type: "pr"; repo: string; number: number }
-  | { type: "http"; requestId: string };
+  | { type: "http"; requestId: string; repo?: string };
 
 export interface IncomingEvent {
   eventId: string;


### PR DESCRIPTION
## Summary
- Add `POST /api/webhooks/github` with HMAC-SHA256 signature validation via `X-Hub-Signature-256` header
- Add `POST /api/webhooks/generic` with API key auth for CI/CD integration
- Support `issue_comment` and `pull_request_review_comment` GitHub events
- Reuse `parseMention()` from github.ts for consistent @mention parsing
- Generic webhook accepts `{ repo, text, userId }` payload with optional userId (defaults to `webhook:generic`)
- GitHub webhook bypasses API key auth (uses its own HMAC signature validation)
- Configure via `GITHUB_WEBHOOK_SECRET` env var (or constructor parameter)

Closes #8

## Test plan
- [x] GitHub webhook with valid HMAC-SHA256 signature accepted (issue_comment)
- [x] GitHub webhook with valid signature accepted (pull_request_review_comment)
- [x] GitHub webhook with invalid signature rejected (401)
- [x] GitHub webhook without signature header rejected (401)
- [x] Comments without @mention skipped gracefully
- [x] Unsupported GitHub event types skipped gracefully
- [x] PR detection from issue_comment on pull requests
- [x] Generic webhook with valid API key accepted (202)
- [x] Generic webhook without API key rejected (401)
- [x] Generic webhook with missing repo/text fields rejected (400)
- [x] Default userId applied when not provided
- [x] Full `bun test` suite passes (260 tests, 0 failures)